### PR TITLE
Raise RuntimeError instead of KeyError if userid was not found on pwchange

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,10 +2,14 @@
 History
 =======
 
-1.2.1 (unreleased)
+1.3.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Raise ``RuntimeError`` instead of ``KeyError`` when password change method
+  couldn't locate the user in LDAP tree. Maybe it's a local user and
+  ``Products.PlonePAS.pas.userSetPassword`` expects a ``RuntimeError`` to be
+  raised in this case.
+  [saily]
 
 
 1.2.0 (2014-03-13)

--- a/src/pas/plugins/ldap/plugin.py
+++ b/src/pas/plugins/ldap/plugin.py
@@ -512,7 +512,12 @@ class LDAPPlugin(BasePlugin):
         """
         users = self.users
         if self.users:
-            self.users.passwd(user_id, None, password)
+            try:
+                self.users.passwd(user_id, None, password)
+            except KeyError:
+                msg = '{0:s} is not an LDAP user.'.format(user_id)
+                logger.warn(msg)
+                raise RuntimeError(msg)
 
     @security.private
     def doDeleteUser(self, login):


### PR DESCRIPTION
`Products.PlonePAS.pas.userSetPassword` expects a `RuntimeError` to be raised if a userid was not found. I'm open for discussion to change that in `Products.PlonePAS`, but we could change it faster here. 

See: https://github.com/plone/Products.PlonePAS/blob/master/Products/PlonePAS/pas.py#L366
