### PR TITLE
Fixed LDAP errors not handled

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ History
 1.5a1 (unreleased)
 ------------------
 
+- Fixed LDAP errors not handled. This prevent leave the site broken
+  just after the installation of the plugin
+  [keul]
+
 - Adopt LDAP instector to use DN instead of RDN for node identification.
   [rnix]
 

--- a/ldap.cfg
+++ b/ldap.cfg
@@ -7,7 +7,7 @@ parts =
 # this build needs (on debian based systems):
 # apt-get install libsasl2-dev libssl-dev libdb-dev
 recipe = zc.recipe.cmmi>=1.1.5
-url = ftp://gd.tuwien.ac.at/infosys/network/OpenLDAP/openldap-release/openldap-2.4.39.tgz
+url = ftp://ftp.openldap.org/pub/OpenLDAP/openldap-release/openldap-2.4.44.tgz
 extra_options = --with-sasl --with-tls --enable-slapd=yes --enable-overlays
 
 

--- a/src/pas/plugins/ldap/defaults.py
+++ b/src/pas/plugins/ldap/defaults.py
@@ -15,13 +15,13 @@ DEFAULTS = {
 
     'users.baseDN':             'ou=users,dc=my-domain,dc=com',
     'users.attrmap':            {
-                                    'rdn': 'uid',
-                                    'id': 'uid',
-                                    'login': 'uid',
-                                    'fullname': 'cn',
-                                    'email': 'mail',
-                                    'location': 'l'
-                                },
+        'rdn': 'uid',
+        'id': 'uid',
+        'login': 'uid',
+        'fullname': 'cn',
+        'email': 'mail',
+        'location': 'l'
+    },
     'users.scope':              ONELEVEL,
     'users.queryFilter':        '(objectClass=inetOrgPerson)',
     'users.objectClasses':      ['inetOrgPerson'],
@@ -32,11 +32,11 @@ DEFAULTS = {
 
     'groups.baseDN':            'ou=groups,dc=my-domain,dc=com',
     'groups.attrmap':           {
-                                    'rdn': 'cn',
-                                    'id': 'cn',
-                                    'title': 'o',
-                                    'description': 'description'
-                                },
+        'rdn': 'cn',
+        'id': 'cn',
+        'title': 'o',
+        'description': 'description'
+    },
     'groups.scope':             ONELEVEL,
     'groups.queryFilter':       '(objectClass=groupOfNames)',
     'groups.objectClasses':     ['groupOfNames'],

--- a/src/pas/plugins/ldap/plugin.py
+++ b/src/pas/plugins/ldap/plugin.py
@@ -50,9 +50,9 @@ manage_addLDAPPluginForm = PageTemplateFile(
 def ldap_error_handler(prefix):
     """decorator, deals with non-working LDAP"""
 
-    def _decorator(original_method):
+    def _decorator(original_method, *args, **kwargs):
 
-        def _wrapper(self):
+        def _wrapper(self, *args, **kwargs):
             # look if error is in timeout phase
             if hasattr(self, '_v_ldaperror_timeout'):
                 waiting = time.time() - self._v_ldaperror_timeout
@@ -69,7 +69,7 @@ def ldap_error_handler(prefix):
             try:
                 # call original method - get metrics
                 start = time.clock()
-                result = original_method(self)
+                result = original_method(self, *args, **kwargs)
                 end = time.clock()
                 logger.debug(
                     'call of {0!r} took {1:0.5f}s'.format(
@@ -182,6 +182,7 @@ class LDAPPlugin(BasePlugin):
     #
     #  Map credentials to a user ID.
     #
+    @ldap_error_handler('authenticateCredentials')
     @security.public
     def authenticateCredentials(self, credentials):
         """credentials -> (userid, login)
@@ -308,6 +309,7 @@ class LDAPPlugin(BasePlugin):
     #
     #   Allow querying users by ID, and searching for users.
     #
+    @ldap_error_handler('enumerateUsers')
     @security.private
     def enumerateUsers(self, id=None, login=None, exact_match=False,
                        sort_by=None, max_results=None, **kw):


### PR DESCRIPTION
See #17.

Added the `ldap_error_handler` decorator to a couple of methods, to prevent the site from stop working simply installing this.