### PR TITLE
Sample config: need ou to successfully authenticate in some instances.

### DIFF
--- a/src/pas/plugins/ldap/defaults.py
+++ b/src/pas/plugins/ldap/defaults.py
@@ -4,7 +4,7 @@ from node.ext.ldap.scope import ONELEVEL
 
 DEFAULTS = {
     'server.uri': 'ldap://127.0.0.1:12345',
-    'server.user': 'cn=Manager,dc=my-domain,dc=com',
+    'server.user': 'cn=Manager,ou=organizational-unit,dc=my-domain,dc=com',
     'server.password': 'secret',
     'server.ignore_cert': False,
     'server.start_tls': False,

--- a/src/pas/plugins/ldap/plonecontrolpanel/profiles/base/ldapsettings.xml
+++ b/src/pas/plugins/ldap/plonecontrolpanel/profiles/base/ldapsettings.xml
@@ -19,7 +19,7 @@
  <element key="groups.scope" type="int">1</element>
  <element key="server.uri" type="string">ldap://127.0.0.1:12345</element>
  <element key="server.user"
-    type="string">cn=Manager,dc=my-domain,dc=com</element>
+    type="string">cn=Manager,ou=organizational-unit,dc=my-domain,dc=com</element>
  <element key="users.attrmap" type="dict">
   <element key="email" type="string">mail</element>
   <element key="fullname" type="string">cn</element>


### PR DESCRIPTION
Added ou to defaults since some instances need it for successful authentication.