### PR TITLE
Check if interface is active when calling a method.

### DIFF
--- a/src/pas/plugins/ldap/plugin.py
+++ b/src/pas/plugins/ldap/plugin.py
@@ -720,7 +720,7 @@ class LDAPPlugin(BasePlugin):
         try:
             group = self.groups[group_id]
         except (KeyError, TypeError):
-            default
+            return default
         return tuple(group.member_ids)
 
     # ##


### PR DESCRIPTION
I had switched off all three group plugins, but got an error calling `getGroupIds` when accessing `@@user-information`.

PAS behaves itself and does not call this when the interface is deactivated, but `pas.plugins.ldap` does call it. So alternatively we could change this and only do these checks when we ourselves need it, to save a (probably small) amount of time.

This pull request also adds `updateUser` and `updateEveryLoginName` as required by `IUserEnumeration`, though we simply return `False` or `None` at the moment.
