### PR TITLE
Set the memcached TTW setting in the form definition to unicode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ History
 1.5.2 (unreleased)
 ------------------
 
+- Set the memcached TTW setting in the form definition to unicode, so that you
+  can save the controlpanel form if you change this field. 
+  [fredvd]
+
 - Improve README
   [svx]
 

--- a/src/pas/plugins/ldap/properties.yaml
+++ b/src/pas/plugins/ldap/properties.yaml
@@ -188,6 +188,7 @@ widgets:
             label: Memcached Server to use
             help: global - same server for all ldap plugins
             field.class: memcached field
+            datatype: unicode
     - timeout:
         factory: '#field:number'
         value: expr:context.props.timeout


### PR DESCRIPTION
So that you can save the controlpanel form if you change this field.

