### PR TITLE
Thread safety for Memcached

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,9 @@
+[isort]
+# https://github.com/timothycrosley/isort/wiki/isort-Settings
+# https://github.com/plone/plone.recipe.codeanalysis
+force_alphabetical_sort=True
+force_single_line = True
+lines_after_imports = 2
+line_length = 200
+not_skip = __init__.py
+skip = bootstrap-buildout.py


### PR DESCRIPTION
The Memcached class of bda.cache is not thread aware. This means that each time the cacheProviderFactory is called, a new connection is established to the memcached. For large LDAP directories, this leads to countless connections that waste system resources and increase the latency of the cache mechanism. This PR fixes the problem. Only one memcachd connection is established per zope thread and can be reused per request by the cacheProviderFactory.