### PR TITLE
Require python-ldap 3.2.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ History
 1.6.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Require python-ldap 3.2.0. Fixes "initialize() got an unexpected keyword
+  argument 'bytes_strictness'".
+  [reinhardt]
 
 
 1.6.1 (2019-05-07)

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         "Products.PlonePAS",
         "Products.PluggableAuthService",
         "Products.statusmessages",
-        "python-ldap",
+        "python-ldap>=3.2.0",
         "setuptools",
         "six",
         "yafowil>=2.3.1",


### PR DESCRIPTION
Fixes ```initialize() got an unexpected keyword argument 'bytes_strictness'``` which prevents LDAP users from logging in.