### PR TITLE
Remove deprecation warning for removal of time.clock() 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ History
 1.6.2 (unreleased)
 ------------------
 
+- Remove deprecation warning for removal of time.clock() which will break
+  Python 3.8 support.
+  [fredvd]
+
 - Require python-ldap 3.2.0. Fixes "initialize() got an unexpected keyword
   argument 'bytes_strictness'".
   [reinhardt]

--- a/src/pas/plugins/ldap/plugin.py
+++ b/src/pas/plugins/ldap/plugin.py
@@ -64,9 +64,13 @@ def ldap_error_handler(prefix, default=None):
                     return default
             try:
                 # call original method - get metrics
-                start = time.clock()
+                if six.PY2:
+                    process_time = time.clock
+                else:
+                    process_time = time.process_time
+                start = process_time()
                 result = original_method(self, *args, **kwargs)
-                end = time.clock()
+                end = process_time()
                 logger.debug(
                     "call of {0!r} took {1:0.5f}s".format(original_method, end - start)
                 )


### PR DESCRIPTION
which will break Python 3.8 support.