### PR TITLE
Added compatibility with node.ext.ldap 1.0b9+. [1.5.x]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,3 @@ install:
   - buildout -Nc buildout-${PLONE_VERSION}.x.cfg buildout:download-cache=downloads code-analysis:return-status-codes=True install ${PART}
 script:
   - bin/${PART}
-after_success:
-  - bin/createcoverage
-  - bin/pip install coverage
-  - bin/python -m coverage.pickle2json
-  - pip install coveralls
-  - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: bionic
 language: python
 sudo: false
 addons:
@@ -11,21 +12,25 @@ cache:
   - eggs
   - downloads
   - openldap
-env:
-  - PLONE_VERSION=4.3
-  - PLONE_VERSION=5.1
-  - PLONE_VERSION=5.2
 python:
   - "2.7"
 matrix:
+  include:
+    - python: "2.7"
+      env: PLONE_VERSION="4.3" PART="test"
+    - python: "2.7"
+      env: PLONE_VERSION="5.1" PART="test"
+    - python: "2.7"
+      env: PLONE_VERSION="5.2" PART="test"
+    - python: "2.7"
+      env: PLONE_VERSION="5.2" PART="code-analysis"
   fast_finish: true
 install:
   - pip install -r requirements-${PLONE_VERSION}.x.txt
   - buildout -Nc buildout-${PLONE_VERSION}.x.cfg buildout:download-cache=downloads code-analysis:return-status-codes=True annotate
-  - buildout -Nc buildout-${PLONE_VERSION}.x.cfg buildout:download-cache=downloads code-analysis:return-status-codes=True
+  - buildout -Nc buildout-${PLONE_VERSION}.x.cfg buildout:download-cache=downloads code-analysis:return-status-codes=True install ${PART}
 script:
-  - bin/code-analysis
-  - bin/test
+  - bin/${PART}
 after_success:
   - bin/createcoverage
   - bin/pip install coverage

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ History
 1.5.4 (unreleased)
 ------------------
 
+- Added compatibility with node.ext.ldap 1.0b9+.
+  There decode_utf8 was renamed to ensure_text,
+  and encode_utf8 to ensure_bytes.  We support both names now.
+  [maurits]
+
 - Fix #51: plone_ldapinspector broken with UnicodeDecodeError
   [dmunico]
 

--- a/src/pas/plugins/ldap/plugin.py
+++ b/src/pas/plugins/ldap/plugin.py
@@ -9,8 +9,6 @@ from Products.PluggableAuthService.interfaces import plugins as pas_interfaces
 from Products.PluggableAuthService.permissions import ManageGroups
 from Products.PluggableAuthService.permissions import ManageUsers
 from Products.PluggableAuthService.plugins.BasePlugin import BasePlugin
-from node.ext.ldap.base import decode_utf8
-from node.ext.ldap.base import encode_utf8
 from node.ext.ldap.interfaces import ILDAPGroupsConfig
 from node.ext.ldap.interfaces import ILDAPProps
 from node.ext.ldap.interfaces import ILDAPUsersConfig
@@ -24,6 +22,14 @@ import ldap
 import logging
 import os
 import time
+
+try:
+    from node.ext.ldap.base import decode_utf8
+    from node.ext.ldap.base import encode_utf8
+except ImportError:
+    # Support newer node.ext.ldap 1.0b9+ where those functions were renamed.
+    from node.ext.ldap.base import ensure_text as decode_utf8
+    from node.ext.ldap.base import ensure_bytes as encode_utf8
 
 
 logger = logging.getLogger('pas.plugins.ldap')


### PR DESCRIPTION
There `decode_utf8` was renamed to `ensure_text`, and `encode_utf8` to `ensure_bytes`.
We support both names now.

Seems to work on Plone 4.3 with latest node.ext.ldap 1.0b11.

After this, a release 1.5.4 would be nice.