### PR TITLE
Fix Travis on 1.5.x branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,3 @@ install:
   - buildout -Nc buildout-${PLONE_VERSION}.x.cfg buildout:download-cache=downloads code-analysis:return-status-codes=True install ${PART}
 script:
   - bin/${PART}
-after_success:
-  - bin/createcoverage
-  - bin/pip install coverage
-  - bin/python -m coverage.pickle2json
-  - pip install coveralls
-  - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: bionic
 language: python
 sudo: false
 addons:
@@ -11,21 +12,25 @@ cache:
   - eggs
   - downloads
   - openldap
-env:
-  - PLONE_VERSION=4.3
-  - PLONE_VERSION=5.1
-  - PLONE_VERSION=5.2
 python:
   - "2.7"
 matrix:
+  include:
+    - python: "2.7"
+      env: PLONE_VERSION="4.3" PART="test"
+    - python: "2.7"
+      env: PLONE_VERSION="5.1" PART="test"
+    - python: "2.7"
+      env: PLONE_VERSION="5.2" PART="test"
+    - python: "2.7"
+      env: PLONE_VERSION="5.2" PART="code-analysis"
   fast_finish: true
 install:
   - pip install -r requirements-${PLONE_VERSION}.x.txt
   - buildout -Nc buildout-${PLONE_VERSION}.x.cfg buildout:download-cache=downloads code-analysis:return-status-codes=True annotate
-  - buildout -Nc buildout-${PLONE_VERSION}.x.cfg buildout:download-cache=downloads code-analysis:return-status-codes=True
+  - buildout -Nc buildout-${PLONE_VERSION}.x.cfg buildout:download-cache=downloads code-analysis:return-status-codes=True install ${PART}
 script:
-  - bin/code-analysis
-  - bin/test
+  - bin/${PART}
 after_success:
   - bin/createcoverage
   - bin/pip install coverage


### PR DESCRIPTION
See what goes wrong in the [Travis jobs](https://travis-ci.org/collective/pas.plugins.ldap/builds/586502697) for PR #78:

- [Plone 4.3](https://travis-ci.org/collective/pas.plugins.ldap/jobs/586502698) fails because of some weird problem installing `configparser` for `code-analysis`. Fixed by installing and running `code-analysis` only on Plone 5.2 in a separate job.
- The others pass, but at the end we do a few commands for `coveralls`, but half of the commands fail, leading to a [blank coveralls report](https://coveralls.io/jobs/53386782
) that apparently defaults to showing 67 percent. Solved by removing the coverage code from the Travis yaml file. We can improve that on master if we want.