### PR TITLE
Default role: Member

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@ History
   Fixes `issue  #95 <https://github.com/collective/pas.plugins.ldap/issues/95>`_.
   [reinhardt]
 
+- Grant the Member role to all LDAP users.
+  [reinhardt]
+
 
 1.7.0 (2020-01-22)
 ------------------
@@ -29,7 +32,6 @@ History
 - Log long running LDAP/ pas.plugin.ldap operations as error.
   Threshold can be controlled with environment variable ``PAS_PLUGINS_LDAP_LONG_RUNNING_LOG_THRESHOLD``.
   [jensens]
-
 
 
 1.6.2 (2019-09-12)

--- a/src/pas/plugins/ldap/plugin.py
+++ b/src/pas/plugins/ldap/plugin.py
@@ -109,6 +109,7 @@ def ldap_error_handler(prefix, default=None):
     pas_interfaces.IGroupsPlugin,
     pas_interfaces.IPropertiesPlugin,
     pas_interfaces.IUserEnumerationPlugin,
+    pas_interfaces.IRolesPlugin,
     plonepas_interfaces.capabilities.IDeleteCapability,
     plonepas_interfaces.capabilities.IGroupCapability,
     plonepas_interfaces.capabilities.IPasswordSetCapability,
@@ -433,6 +434,18 @@ class LDAPPlugin(BasePlugin):
         if max_results and len(ret) > max_results:
             ret = ret[:max_results]
         return ret
+
+    # ##
+    # pas_interfaces.plugins.IRolesPlugin
+    #
+    def getRolesForPrincipal(self, principal, request=None):
+        default = ()
+        users = self.users
+        if not users:
+            return default
+        if self.enumerateUsers(id=principal.getId()):
+            return ('Member', )
+        return default
 
     @security.private
     def updateUser(self, user_id, login_name):

--- a/src/pas/plugins/ldap/tests/test_plugin.py
+++ b/src/pas/plugins/ldap/tests/test_plugin.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from pas.plugins.ldap.testing import PASLDAP_FIXTURE
+from Products.PlonePAS.plugins.ufactory import PloneUser
 
 import unittest
 
@@ -316,3 +317,15 @@ class TestPluginFeatures(unittest.TestCase):
         )
         # no delete support:
         self.assertFalse(self.ldap.doDeleteUser("uid0"))
+
+    def test_IRolesPlugin(self):
+        ldap_user = PloneUser('uid0', login='cn0')
+        self.assertEqual(
+            self.ldap.getRolesForPrincipal(ldap_user),
+            ('Member', ),
+        )
+        other_user = PloneUser('unknown', login='other')
+        self.assertEqual(
+            self.ldap.getRolesForPrincipal(other_user),
+            (),
+        )


### PR DESCRIPTION
This grants the Member role to all LDAP users. The next obvious step is to make it configurable what roles to grant.

<del>Work in progress.</del>