### PR TITLE
Import loader from YAFOWIL.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,8 +15,10 @@ New features:
 
 Bug fixes:
 
-- *add item here*
-
+- Import loader from YAFOWIL.
+  Fixes `issue #97 <https://github.com/collective/pas.plugins.ldap/issues/97>`_
+  and `issue #92 <https://github.com/collective/pas.plugins.ldap/issues/92>`_.
+  [al45tair]
 
 1.7.1 (2020-02-14)
 ------------------

--- a/src/pas/plugins/ldap/properties.py
+++ b/src/pas/plugins/ldap/properties.py
@@ -13,7 +13,7 @@ from pas.plugins.ldap.defaults import DEFAULTS
 from pas.plugins.ldap.interfaces import ICacheSettingsRecordProvider
 from pas.plugins.ldap.interfaces import ILDAPPlugin
 from Products.Five import BrowserView
-from yafowil import loader
+from yafowil import loader # noqa: F401
 from yafowil.base import ExtractionError
 from yafowil.base import UNSET
 from yafowil.controller import Controller

--- a/src/pas/plugins/ldap/properties.py
+++ b/src/pas/plugins/ldap/properties.py
@@ -13,6 +13,7 @@ from pas.plugins.ldap.defaults import DEFAULTS
 from pas.plugins.ldap.interfaces import ICacheSettingsRecordProvider
 from pas.plugins.ldap.interfaces import ILDAPPlugin
 from Products.Five import BrowserView
+from yafowil import loader
 from yafowil.base import ExtractionError
 from yafowil.base import UNSET
 from yafowil.controller import Controller

--- a/src/pas/plugins/ldap/properties.py
+++ b/src/pas/plugins/ldap/properties.py
@@ -13,7 +13,7 @@ from pas.plugins.ldap.defaults import DEFAULTS
 from pas.plugins.ldap.interfaces import ICacheSettingsRecordProvider
 from pas.plugins.ldap.interfaces import ILDAPPlugin
 from Products.Five import BrowserView
-from yafowil import loader # noqa: F401
+from yafowil import loader  # noqa: F401
 from yafowil.base import ExtractionError
 from yafowil.base import UNSET
 from yafowil.controller import Controller


### PR DESCRIPTION
Without doing this, various built-in widgets aren't registered, which
results in mysterious KeyError messages when people try to configure
LDAP in Plone.

Fixes #97 and #92.