### PR TITLE
ldap connection/operation timeouts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ History
 1.8.2 (unreleased)
 ------------------
 
-- No changes yet.
+- Add connection and operation timeout properties for LDAP server.
+  Fixes `issue #61 <https://github.com/collective/pas.plugins.ldap/issues/61>`_.
+  [mamico]
 
 
 1.8.1 (2021-10-09)

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         "bda.cache",
         "five.globalrequest",
         "node",
-        "node.ext.ldap>=1.0b12",
+        "node.ext.ldap>=1.1.dev0",
         "odict",
         "plone.registry",
         "Products.CMFCore",

--- a/src/pas/plugins/ldap/defaults.py
+++ b/src/pas/plugins/ldap/defaults.py
@@ -9,6 +9,8 @@ DEFAULTS = {
     "server.ignore_cert": False,
     "server.start_tls": False,
     "server.page_size": 1000,
+    "server.conn_timeout": 5,
+    "server.op_timeout": 600,
     "cache.cache": False,
     "cache.memcached": "127.0.0.1:11211",
     "cache.timeout": 300,  # seconds

--- a/src/pas/plugins/ldap/properties.py
+++ b/src/pas/plugins/ldap/properties.py
@@ -124,6 +124,8 @@ class BasePropertiesForm(BrowserView):
         # props.retry_max = fetch(at('server.retry_max')
         # props.retry_delay = fetch('server.retry_delay')
         props.page_size = fetch("server.page_size")
+        props.conn_timeout = fetch("server.conn_timeout")
+        props.op_timeout = fetch("server.op_timeout")
         props.cache = fetch("cache.cache")
         props.memcached = fetch("cache.memcached")
         props.timeout = fetch("cache.timeout")
@@ -257,6 +259,8 @@ class LDAPProps(object):
     start_tls = propproxy("server.start_tls")
     ignore_cert = propproxy("server.ignore_cert")
     page_size = propproxy("server.page_size")
+    conn_timeout = propproxy("server.conn_timeout")
+    op_timeout = propproxy("server.op_timeout")
     cache = propproxy("cache.cache")
     timeout = propproxy("cache.timeout")
 

--- a/src/pas/plugins/ldap/properties.yaml
+++ b/src/pas/plugins/ldap/properties.yaml
@@ -26,6 +26,18 @@ widgets:
         default: False
         props:
             label: Anonymous Connection?
+    - conn_timeout:
+        factory: '#field:number'
+        value: expr:context.props.conn_timeout
+        props:
+            label: LDAP connection timeout in seconds
+            datatype: integer
+    - op_timeout:
+        factory: '#field:number'
+        value: expr:context.props.op_timeout
+        props:
+            label: LDAP operation timeout in seconds
+            datatype: integer
     - user:
         factory: '#field:text'
         value: expr:context.props.user


### PR DESCRIPTION
Requires the currently unreleased node.ext.ldap 1.1

The defaults in LDAPUserFolder are 5s for connection and no timeout for operations
https://github.com/dataflake/Products.LDAPUserFolder/blob/master/src/Products/LDAPUserFolder/LDAPUserFolder.py#L403

IMHO 600s as operating timeout is enough for Plone (in a production site probably my suggestion is to have a lower value), but no problem to set no timeout as default as former LDAP pas plugin.