### PR TITLE
use exact_match in getRolesForPrincipal/getPropertiesForUser

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ History
 1.8.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix: use exact_match for searchUsers/searchGroups in getRolesForPrincipal/getPropertiesForUser
+  to avoid unexpected results
+  [mamico]
 
 
 1.8.2 (2022-10-31)

--- a/src/pas/plugins/ldap/plugin.py
+++ b/src/pas/plugins/ldap/plugin.py
@@ -439,7 +439,7 @@ class LDAPPlugin(BasePlugin):
         users = self.users
         if not users:
             return default
-        if self.enumerateUsers(id=principal.getId()):
+        if self.enumerateUsers(id=principal.getId(), exact_match=True):
             return ("Member",)
         return default
 
@@ -561,7 +561,9 @@ class LDAPPlugin(BasePlugin):
         if not isinstance(ugid, six.text_type):
             ugid = ugid.decode("utf-8")
         try:
-            if self.enumerateUsers(id=ugid) or self.enumerateGroups(id=ugid):
+            if self.enumerateUsers(id=ugid, exact_match=True) or self.enumerateGroups(
+                id=ugid, exact_match=True
+            ):
                 return LDAPUserPropertySheet(user_or_group, self)
         except KeyError:
             pass
@@ -687,7 +689,6 @@ class LDAPPlugin(BasePlugin):
         for propfinder_id, propfinder in plugins.listPlugins(
             pas_interfaces.IPropertiesPlugin
         ):
-
             data = propfinder.getPropertiesForUser(group, None)
             if not data:
                 continue
@@ -696,7 +697,6 @@ class LDAPPlugin(BasePlugin):
         group._addGroups(pas._getGroupsForPrincipal(group, None, plugins=plugins))
         # add roles
         for rolemaker_id, rolemaker in plugins.listPlugins(pas_interfaces.IRolesPlugin):
-
             roles = rolemaker.getRolesForPrincipal(group, None)
             if not roles:
                 continue


### PR DESCRIPTION
This is probably an edge case, but it has happened and may happen to others.

If you have a local user or group named `cekk` and an ldap user named `cekk@redturtle.it`, the actual code looks up the properties of an inexistent `cekk` user in ldap, and eventually an error occurs with this trace

```
  Module pas.plugins.ldap.plugin, line 565, in getPropertiesForUser
  Module pas.plugins.ldap.sheet, line 40, in __init__
  Module pas.plugins.ldap.sheet, line 60, in _get_ldap_principal
  Module node.locking, line 30, in _locktree_decorator
  Module node.ext.ldap.ugm._api, line 536, in __getitem__
  Module node.utils, line 275, in wrapped
  Module node.ext.ldap._node, line 512, in search
  Module node.ext.ldap.session, line 44, in search
  Module node.ext.ldap.base, line 288, in search
  Module node.ext.ldap.base, line 263, in _search
  Module ldap.ldapobject, line 544, in result3
  Module ldap.ldapobject, line 554, in result4
  Module ldap.ldapobject, line 128, in _ldap_call
ldap.NO_SUCH_OBJECT: {'msgtype': 101, 'msgid': 2, 'result': 32, 'desc': 'No such object', 'ctrls': []}

```