### PR TITLE
fix: avoid credential logging in debug mode

### DIFF
--- a/src/pas/plugins/ldap/plugin.py
+++ b/src/pas/plugins/ldap/plugin.py
@@ -221,7 +221,7 @@ class LDAPPlugin(BasePlugin):
         pw = credentials.get("password")
         if not (login and pw):
             return default
-        logger.debug("credentials: %s" % credentials)
+        logger.debug("login: %s" % login)
         users = self.users
         if not users:
             return default


### PR DESCRIPTION
Log only login name but not the password in debug mode.