### PR TITLE
[1.8] Remove five.globalrequest

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,10 @@ History
 1.8.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove the dependency from ``five.globalrequest``.
+  This is needed to make this package work on Plone 6.1.2.
+  See `PR #134 <https://github.com/collective/pas.plugins.ldap/pull/134>`_.
+  [cillianderoiste]
 
 
 1.8.3 (2024-11-13)

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ setup(
         "AccessControl>=3.0",
         "Acquisition",
         "bda.cache",
-        "five.globalrequest",
         "node",
         "node.ext.ldap>=1.1",
         "odict",

--- a/src/pas/plugins/ldap/configure.zcml
+++ b/src/pas/plugins/ldap/configure.zcml
@@ -6,8 +6,6 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     i18n_domain="pas.plugins.ldap">
 
-  <include package="five.globalrequest" />
-
   <five:registerPackage package="." initialize=".initialize" />
 
   <include package="Products.GenericSetup" file="meta.zcml" />


### PR DESCRIPTION
This is a backport of https://github.com/collective/pas.plugins.ldap/pull/134.

The package `five.globalrequest` has been integrated since Zope 4 and breaks in Plone 6.1.2

See: https://github.com/plone/Products.CMFPlone/issues/2618