### PR TITLE
fix: correct permission name in controlpanel.xml (Manage Portal -> Manage portal)

### DIFF
--- a/src/pas/plugins/ldap/plonecontrolpanel/profiles/default/controlpanel.xml
+++ b/src/pas/plugins/ldap/plonecontrolpanel/profiles/default/controlpanel.xml
@@ -13,6 +13,6 @@
              visible="True"
              i18n:attributes="title"
   >
-    <permission>Manage Portal</permission>
+    <permission>Manage portal</permission>
   </configlet>
 </object>


### PR DESCRIPTION
## Bug Description

The `pas.plugins.ldap` control panel configlet in Plone's Site Setup uses an incorrect permission name casing — `Manage Portal` (capital 'P') instead of the canonical `Manage portal` (lowercase 'p').

This prevents the configlet from inheriting the correct Zope permission binding. Depending on the Plone version and how the permission registry resolves case-sensitive lookups, this can result in:

- The LDAP configlet being invisible to users who *should* have access (Site Administrators)
- The configlet being accessible only to users with the broad `Manager` role, when it should follow Plone's standard `Site Administrator` permission model
- Inconsistencies with other Plone addons that correctly reference `Manage portal`

Fixes: implicit bug in `controlpanel.xml` introduced in commit `cafbfdd` ("Added more improvements about i18n support #131")

## Root Cause

In Plone's security architecture, permissions are registered as string identifiers in `Products.CMFCore`'s `permissions.zcml`. The permission `<permission>Manage portal</permission>` (lowercase 'p') is the canonical Zope 2 permission title used by:

- **CMFPlone's own `controlpanel.xml`** — all built-in Plone control panel configlets use `Manage portal`
- **Products.LoginLockout** — [`controlpanel.xml`](https://github.com/collective/Products.LoginLockout/blob/master/Products/LoginLockout/profiles/uninstall/controlpanel.xml)
- **Plone's `rolemap.xml`** — assigns `Manage portal` to the `Site Administrator` role

The original code in commit `cafbfdd` used `Manage Portal` (capital 'P'). This is a case mismatch against the registered permission string. Zope's security machinery does a string lookup against `AccessControl`'s permission registry — a mismatched string either fails silently (configlet hidden) or falls back to a less-restricted default.

## Fix

**One character change** in `src/pas/plugins/ldap/plonecontrolpanel/profiles/default/controlpanel.xml`:

```diff
-    <permission>Manage Portal</permission>
+    <permission>Manage portal</permission>
```

This aligns the configlet with Plone's canonical permission name, ensuring it follows the standard access control model where `Site Administrator` role holders can access the LDAP configuration without requiring full `Manager` privileges.

## How to Verify

1. Install `pas.plugins.ldap` in a Plone 5.x or 6.x site
2. Log in as a user with the `Site Administrator` role (not `Manager`)
3. Navigate to **Site Setup** → **Users and Groups** category
4. Confirm the "LDAP / AD Support" configlet is visible and clickable
5. Before this fix: the configlet may be invisible to `Site Administrator` users (only visible to `Manager`)
6. After this fix: the configlet follows standard Plone permission inheritance

## Test Plan

- [x] Verified `Manage portal` is the canonical permission string in `Products.CMFCore`
- [x] Verified other well-maintained Plone addons (`Products.LoginLockout`) use `Manage portal`
- [ ] Existing tests still pass (no functional code change, only XML metadata)
- [ ] Manual verification on Plone 6 Classic

## Risk Assessment

**Low** — This is a metadata-only change to a GenericSetup XML profile. It affects only:

- The permission binding of the control panel configlet (one attribute, one line)
- No Python code, no templates, no workflows, no schema changes

The change cannot break existing LDAP configurations, user authentication, or any runtime behavior. It only corrects how Plone's Site Setup page decides who can see and click the LDAP configlet.
