### PR TITLE
Release prep 2.0.0: fix blockers for Plone 6.0-6.2 release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,10 +29,31 @@ History
 - Refactor test setup to use pytest as runner.
   [jensens]
 
-- Increase PAS_PLUGINS_LDAP_OPT_TIMEOUT t
+- Increase the default of the ``PAS_PLUGINS_LDAP_OPT_TIMEOUT`` overall
+  operation timeout from 2.0 to 30.0 seconds.
+  [jensens]
 
-- Remove five.globalrequest dependency.
-  [cillianderoiste]
+- Remove ``five.globalrequest`` dependency.
+  The package now only depends on ``zope.globalrequest``, which was the only
+  one actually imported. Removes the stale dependency declaration.
+  [cillianderoiste, jensens]
+
+- Drop the unused ``six`` dependency.
+  Fix the portrait property-sheet support to use ``io.BytesIO`` instead of the
+  text-only ``six.StringIO``, which raised a ``TypeError`` on binary image data.
+  [jensens]
+
+- ``getRolesForPrincipal`` now honors the activation state of the
+  ``IRolesPlugin`` interface and is declared ``@security.private`` like the
+  other PAS interface methods.
+  Note: as part of the new default user roles feature, LDAP users receive the
+  configured roles (default ``Member``) only when the *Roles* plugin interface
+  is activated for this plugin.
+  [jensens]
+
+- Fix the LDAP inspector raising a ``TypeError`` (bytes dict key) when a node
+  attribute could not be decoded; the error is now reported gracefully again.
+  [jensens]
 
 - Add i18n support and Spanish translation.
   [macagua]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ classifiers = [
 ]
 dependencies = [
     "bda.cache",
-    "five.globalrequest",
     "node.ext.ldap>=2.0.0",
     "odict",
     "plone.api",

--- a/src/pas/plugins/ldap/monkey.py
+++ b/src/pas/plugins/ldap/monkey.py
@@ -4,12 +4,12 @@
 # until this is changed upstream!
 from Acquisition import aq_inner
 from Acquisition import aq_parent
+from io import BytesIO
 from OFS.Image import Image
 from Products.CMFCore.utils import getToolByName
 from Products.PlonePAS.tools.membership import _checkPermission
 from Products.PlonePAS.tools.membership import default_portrait
 from Products.PlonePAS.tools.membership import MembershipTool
-from six import StringIO
 from zope.interface import implementer
 from zope.traversing.interfaces import ITraversable
 
@@ -43,8 +43,9 @@ def getPortraitFromSheet(context, userid):
         # nothing found on sheet
         return None
     # turn into OFS.Image
-    sio = StringIO()
+    sio = BytesIO()
     sio.write(portrait)
+    sio.seek(0)
     content_type = "image/jpeg"  # XXX sniff it
     portrait = PortraitImage(userid, user.getProperty("fullname"), sio, content_type)
     return portrait

--- a/src/pas/plugins/ldap/plonecontrolpanel/inspector.py
+++ b/src/pas/plugins/ldap/plonecontrolpanel/inspector.py
@@ -12,13 +12,6 @@ from zope.component import getUtility
 import json
 
 
-def safe_encode(val):
-    """Encode a value to bytes if it's a string, otherwise return it as is."""
-    if isinstance(val, str):
-        return val.encode("utf-8")
-    return val
-
-
 class LDAPInspector(BrowserView):
     """A view to inspect the LDAP directory structure and attributes for
     debugging purposes."""
@@ -67,9 +60,9 @@ class LDAPInspector(BrowserView):
                         len(val)
                     )
             except UnicodeDecodeError:
-                ret[safe_encode(key)] = "! (UnicodeDecodeError)"
+                ret[safe_unicode(key)] = "! (UnicodeDecodeError)"
             except Exception:
-                ret[safe_encode(key)] = "! (Unknown Exception)"
+                ret[safe_unicode(key)] = "! (Unknown Exception)"
         return json.dumps(ret)
 
     def children(self, baseDN):

--- a/src/pas/plugins/ldap/plonecontrolpanel/profiles/default/metadata.xml
+++ b/src/pas/plugins/ldap/plonecontrolpanel/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-  <version>1</version>
+  <version>2</version>
   <dependencies>
     <dependency>profile-pas.plugins.ldap:default</dependency>
     <dependency>profile-yafowil.plone:default</dependency>

--- a/src/pas/plugins/ldap/plugin.py
+++ b/src/pas/plugins/ldap/plugin.py
@@ -23,7 +23,6 @@ from zope.interface import implementer
 import ldap
 import logging
 import os
-import six
 import time
 
 logger = logging.getLogger("pas.plugins.ldap")
@@ -450,6 +449,7 @@ class LDAPPlugin(BasePlugin):
     # ##
     # pas_interfaces.plugins.IRolesPlugin
     #
+    @security.private
     def getRolesForPrincipal(self, principal, request=None):
         """Get the roles for a principal.
 
@@ -461,6 +461,8 @@ class LDAPPlugin(BasePlugin):
             tuple: A tuple of roles for the principal.
         """
         default = ()
+        if not self.is_plugin_active(pas_interfaces.IRolesPlugin):
+            return default
         users = self.users
         if not users:
             return default

--- a/tests/test_monkey_unit.py
+++ b/tests/test_monkey_unit.py
@@ -130,7 +130,7 @@ class TestGetPortraitFromSheet(unittest.TestCase):
         with patch("pas.plugins.ldap.monkey.getToolByName", return_value=mtool), \
              patch("pas.plugins.ldap.monkey.PortraitImage",
                    return_value=mock_portrait_img), \
-             patch("pas.plugins.ldap.monkey.StringIO"):
+             patch("pas.plugins.ldap.monkey.BytesIO"):
             result = getPortraitFromSheet(context, "uid0")
         self.assertIs(result, mock_portrait_img)
 
@@ -145,7 +145,7 @@ class TestGetPortraitFromSheet(unittest.TestCase):
         mock_sio = MagicMock()
         with patch("pas.plugins.ldap.monkey.getToolByName", return_value=mtool), \
              patch("pas.plugins.ldap.monkey.PortraitImage") as MockPI, \
-             patch("pas.plugins.ldap.monkey.StringIO", return_value=mock_sio):
+             patch("pas.plugins.ldap.monkey.BytesIO", return_value=mock_sio):
             getPortraitFromSheet(context, "testuser")
 
         MockPI.assert_called_once_with("testuser", "Jane Doe", mock_sio, "image/jpeg")

--- a/tests/test_plugin_unit.py
+++ b/tests/test_plugin_unit.py
@@ -503,8 +503,18 @@ class TestGetRolesForPrincipal(unittest.TestCase):
     def setUp(self):
         self.plugin = _make_plugin()
 
+    def test_returns_empty_when_not_active(self):
+        """Returns () when the IRolesPlugin interface is not active."""
+        self.plugin.is_plugin_active = MagicMock(return_value=False)
+        with patch.object(type(self.plugin), "users", new_callable=PropertyMock) as pu:
+            pu.return_value = MagicMock()
+            principal = MagicMock()
+            result = self.plugin.getRolesForPrincipal(principal)
+        self.assertEqual(result, ())
+
     def test_returns_empty_when_no_users(self):
         """Returns () when self.users is None (line 466)."""
+        self.plugin.is_plugin_active = MagicMock(return_value=True)
         with patch.object(type(self.plugin), "users", new_callable=PropertyMock) as pu:
             pu.return_value = None
             principal = MagicMock()
@@ -1003,6 +1013,7 @@ class TestGetRolesForPrincipalNotFound(unittest.TestCase):
     def test_returns_empty_when_enumerateusers_finds_nothing(self):
         """Returns () when users is truthy but enumerateUsers returns () (line 469)."""
         plugin = _make_plugin()
+        plugin.is_plugin_active = MagicMock(return_value=True)
         mock_users = MagicMock()
         mock_users.search.return_value = []  # enumerateUsers will return ()
         principal = MagicMock()


### PR DESCRIPTION
Release-readiness fixes found while reviewing `main` for the **2.0.0** release (targeting Plone 6.0–6.2). Each fix below was a blocker or strongly-recommended item; non-critical findings are tracked separately as issues.

## Fixes

- **Drop unused `six` dependency.** `monkey.py` imported `six.StringIO` (a *text* stream) at import time (loaded via `__init__.py`) and wrote binary JPEG portrait data into it → `TypeError` for any user with a portrait. Switched to `io.BytesIO` (+ `seek(0)`). `six` was never declared as a dependency, so this was also a latent startup `ImportError` risk. Also removed the unused `import six` in `plugin.py`.
- **Remove stale `five.globalrequest` dependency.** Only `zope.globalrequest` is actually imported; the changelog already claimed this dependency was removed.
- **`getRolesForPrincipal` activation guard + security.** Added the `is_plugin_active(IRolesPlugin)` check and `@security.private`, mirroring every other PAS interface method. Without it, the new *default user roles* feature assigned roles unconditionally, even when the Roles interface was deactivated.
- **LDAP inspector `json.dumps` crash.** The `except` branches used `safe_encode(key)` (bytes) as dict keys → `TypeError` exactly in the decode-error case the code tries to handle gracefully. Now uses `safe_unicode(key)`; dropped the now-unused `safe_encode` helper.
- **Profile version consistency.** Bumped `plonecontrolpanel:default` `metadata.xml` `1 → 2` to match the registered upgrade step's `destination="2"` (avoids a spurious "upgrade available" on fresh installs).
- **CHANGES.rst.** Completed a truncated `PAS_PLUGINS_LDAP_OPT_TIMEOUT` entry (default raised 2.0 → 30.0s) and documented the fixes above.

## Testing

Full suite green locally — unit + LDAP integration (local slapd) + doctests:

```
239 passed
```

`isort --profile plone` and `black` clean on `src/`. CI runs the full Plone 6.0.14 / 6.1.2 / 6.2.0 × Python 3.10–3.14 matrix.

## Not included (release-time / follow-up)

- Version bump `2.0.0.dev0 → 2.0.0` is left to the release tooling.
- Ensure the release pipeline runs `make gettext-compile` so `.mo` catalogs ship (they are gitignored).
- Non-critical findings (connection-test on every render, `reset()` no-op, etc.) will be filed as separate issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)