### PR TITLE
Fix portrait traverser to 404 when user has no portrait (#68)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,12 @@ History
 2.0.0 (unreleased)
 ------------------
 
+- Portrait traverser: raise a proper ``LocationError`` (404) when a user has
+  no portrait on the property sheet, instead of an ``AttributeError`` from
+  calling ``__of__`` on ``None``.
+  Fixes `issue #68 <https://github.com/collective/pas.plugins.ldap/issues/68>`_.
+  [jensens]
+
 - Fixed the "LDAP / Active Directory Configuration" controlpanel uses wrong permission.
   [szakitibi, macagua]
 

--- a/src/pas/plugins/ldap/monkey.py
+++ b/src/pas/plugins/ldap/monkey.py
@@ -11,6 +11,7 @@ from Products.PlonePAS.tools.membership import _checkPermission
 from Products.PlonePAS.tools.membership import default_portrait
 from Products.PlonePAS.tools.membership import MembershipTool
 from zope.interface import implementer
+from zope.location.interfaces import LocationError
 from zope.traversing.interfaces import ITraversable
 
 
@@ -61,7 +62,11 @@ class PortraitTraverser:
 
     def traverse(self, userid, subpath):
         """Traverse to the portrait image for a user."""
-        return getPortraitFromSheet(self.context, userid).__of__(self.context)
+        portrait = getPortraitFromSheet(self.context, userid)
+        if portrait is None:
+            # no portrait on the user's property sheet -> not found
+            raise LocationError(self.context, userid)
+        return portrait.__of__(self.context)
 
 
 def patched_getPersonalPortrait(self, id=None, verifyPermission=0):

--- a/tests/test_monkey_unit.py
+++ b/tests/test_monkey_unit.py
@@ -201,6 +201,19 @@ class TestPortraitTraverser(unittest.TestCase):
         self.assertEqual(of_calls, [ctx])
         self.assertIs(result, mock_wrapped)
 
+    def test_traverse_raises_when_no_portrait(self):
+        """traverse raises LocationError when the user has no portrait."""
+        from zope.location.interfaces import LocationError
+
+        ctx = MagicMock()
+        traverser = PortraitTraverser(ctx)
+        with patch(
+            "pas.plugins.ldap.monkey.getPortraitFromSheet",
+            return_value=None,
+        ):
+            with self.assertRaises(LocationError):
+                traverser.traverse("uid0", [])
+
 
 # ---------------------------------------------------------------------------
 # patched_getPersonalPortrait  (lines 72-94)


### PR DESCRIPTION
Fixes #68.

`PortraitTraverser.traverse()` called `.__of__()` unconditionally on the result of `getPortraitFromSheet()`, which returns `None` when the user has no `portrait` on their property sheet → `AttributeError: 'NoneType' object has no attribute '__of__'`.

Now it raises `zope.location.interfaces.LocationError` (a `KeyError` subclass that Zope publishes as **NotFound**), so the `++portrait++` traversal returns a clean 404 instead of a 500.

This is the remaining part of #68; the binary-portrait construction crash (`StringIO` → `BytesIO`) was already fixed in #144.

## Testing
- Added a unit test asserting `LocationError` is raised when no portrait exists.
- Full suite green (unit + LDAP integration + doctests): **240 passed**.
- `isort --profile plone` / `black` clean on `src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)