### PR TITLE
Compile and ship .mo translation catalogs at build time (#146)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,12 @@ History
   Fixes `issue #68 <https://github.com/collective/pas.plugins.ldap/issues/68>`_.
   [jensens]
 
+- Compile the gettext ``.po`` catalogs to ``.mo`` automatically during the
+  build (hatchling build hook) and ship them in the sdist and wheel, so the
+  translations are active for installs from PyPI without a manual
+  ``make gettext-compile`` step.
+  [jensens]
+
 - Fixed the "LDAP / Active Directory Configuration" controlpanel uses wrong permission.
   [szakitibi, macagua]
 

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,0 +1,38 @@
+"""Hatchling build hook.
+
+Compiles the gettext ``.po`` message catalogs to ``.mo`` at build time and
+force-includes them into the built sdist and wheel.
+
+The ``.mo`` files are not kept in version control (they are generated
+artifacts, see ``.gitignore``).  Without this hook they would only end up in a
+release if ``make gettext-compile`` happened to be run before building, so the
+Spanish translation would silently be missing for end users installing from
+PyPI.  Compiling them as part of the build makes the result correct regardless
+of how or where the package is built.
+"""
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+from pathlib import Path
+
+LOCALES = Path("src/pas/plugins/ldap/locales")
+
+
+class CompileCatalogsBuildHook(BuildHookInterface):
+    """Compile ``.po`` catalogs to ``.mo`` and include them in the artifact."""
+
+    PLUGIN_NAME = "compile-catalogs"
+
+    def initialize(self, version, build_data):
+        from babel.messages.mofile import write_mo
+        from babel.messages.pofile import read_po
+
+        root = Path(self.root)
+        locales = root / LOCALES
+        for po_path in sorted(locales.glob("*/LC_MESSAGES/*.po")):
+            mo_path = po_path.with_suffix(".mo")
+            with po_path.open("rb") as fh:
+                catalog = read_po(fh)
+            with mo_path.open("wb") as fh:
+                write_mo(fh, catalog)
+            # the .mo files are gitignored, so force them into the artifact
+            build_data["force_include"][str(mo_path)] = str(mo_path.relative_to(root))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,8 +70,11 @@ Homepage = "https://github.com/collective/pas.plugins.ldap/"
 "Source Code" = "https://github.com/collective/pas.plugins.ldap"
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "babel"]
 build-backend = "hatchling.build"
+
+[tool.hatch.build.hooks.custom]
+path = "hatch_build.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/pas"]


### PR DESCRIPTION
Fixes #146.

The `.mo` message catalogs are gitignored build artifacts, so they only made it into a release if `make gettext-compile` happened to be run before building — otherwise the Spanish translation was silently missing for users installing from PyPI.

## Change
- Add a hatchling **custom build hook** ([`hatch_build.py`](hatch_build.py)) that compiles every `locales/<lang>/LC_MESSAGES/*.po` → `.mo` with **Babel** and force-includes them into the sdist and wheel (they are gitignored, so `build_data["force_include"]` is used).
- Add `babel` to `[build-system].requires` so it is available in the isolated build environment.

The `.mo` files stay out of version control; they are produced deterministically at build time, regardless of who builds or whether `make gettext-compile` was run.

## Verification
`python -m build` (isolated) produces:

```
pas/plugins/ldap/locales/en/LC_MESSAGES/pas.plugins.ldap.mo
pas/plugins/ldap/locales/es/LC_MESSAGES/pas.plugins.ldap.mo
```

in **both** the wheel and the sdist. The compiled `es` catalog loads via `gettext` with 105 real translations (e.g. *"Connection Test" → "Prueba de conexión"*).

🤖 Generated with [Claude Code](https://claude.com/claude-code)