### PR TITLE
Fix control-panel property widgets hidden by pat-autotoc (#154)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,14 @@
 
 ## 2.0.0 (unreleased)
 
+- Fix the user/group property-mapping widgets disappearing from the Plone
+  control panel: scope the `pat-autotoc` tabbing to the top-level
+  `fieldset.formPanel` sections so it no longer hides the nested, legend-less
+  fieldsets rendered by the `yafowil.widget.dict` / `yafowil.widget.array`
+  widgets.
+  Fixes [issue #154](https://github.com/collective/pas.plugins.ldap/issues/154).
+  [jensens]
+
 - Derive the package version from git tags via `hatch-vcs` (the static
   `version` in `pyproject.toml` is gone). Releases are now made by tagging.
   [jensens]

--- a/src/pas/plugins/ldap/properties.yaml
+++ b/src/pas/plugins/ldap/properties.yaml
@@ -4,7 +4,13 @@ props:
     action: expr:context.action
     class: edit-form enableFormTabbing pat-autotoc enableUnloadProtection
     data:
-        pat-autotoc: "levels: legend; section: fieldset; className: autotabs"
+        # Scope the auto-TOC tabbing to the top-level section fieldsets only
+        # (server/users/groups/cache all carry the ``formPanel`` class).
+        # A bare ``section: fieldset`` also matched the nested, legend-less
+        # ``<fieldset>`` wrappers that yafowil.widget.dict / .array render,
+        # which made pat-autotoc hide the user/group property-mapping widgets
+        # in the Plone control panel (see issue #154).
+        pat-autotoc: "levels: legend; section: fieldset.formPanel; className: autotabs"
 widgets:
 - server:
     factory: "*userpassanon:fieldset"


### PR DESCRIPTION
Fixes #154.

## Problem
After upgrading to 2.0.0rc1, the **user/group property-mapping widgets** are missing from the Plone control panel (they are present in the ZMI, and the data is intact).

## Root cause
See the [detailed analysis in #154](https://github.com/collective/pas.plugins.ldap/issues/154#issuecomment-4835014579). In short:

- The dict/array widgets render correct server-side HTML, but `yafowil.widget.dict` 2.0 wraps itself in a **nested, legend-less `<fieldset>`**.
- The new UX added `pat-autotoc` with `section: fieldset`, which turns **every** `<fieldset>` into a tab section — including those nested widget fieldsets — so they get hidden in the browser.
- The ZMI works because it has no `pat-autotoc`.

## Fix
Scope the auto-TOC tabbing to the top-level section fieldsets only (`server`/`users`/`groups`/`cache` all carry `class: formPanel`):

```diff
-        pat-autotoc: "levels: legend; section: fieldset; className: autotabs"
+        pat-autotoc: "levels: legend; section: fieldset.formPanel; className: autotabs"
```

The nested widget fieldsets no longer match the section selector.

## ⚠️ Verification
This is a **browser-side** fix — the server-side HTML was already correct, so the existing Python/unit tests can't reproduce or prove it (they stay green either way). **Please verify in a browser on an affected instance** (the control panel should again show the *User attribute aliases*, *User Property-Sheet Attributes*, and the group equivalents). 240 unit/integration/doctest tests still pass.

## Follow-up (not in this PR)
The form has **both** `enableFormTabbing` and `pat-autotoc` active — two tabbing mechanisms on the same form. Worth revisiting whether both are intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)